### PR TITLE
Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ which defines each of these quantities and passes them to the libsdp solver.
 
 ## Methods and Functionality
 
-The following methods and objects are exposed at the Python layer:
+The following methods and objects are accessible in libsdp and libsdp.sdp_helper:
 
-#### libsdp.sdp_matrix()
+#### libsdp.sdp_helper.sdp_matrix()
 
 Returns a struct for SDPA-style sparse matrix entries. Each row of the sparse matrix has elements that map to the elements of the primal solution vector for evaluating matrix-vector products (e.g, for Ax = b). A row of A can be encoded with the following elements of the sdp_matrix() struct:
 
@@ -169,21 +169,23 @@ The options object also defines the enums used to specify sdp_algorithm:
 
 Default settings can be found in libsdp/include/sdp_solver.h
 
-#### libsdp.sdp_solver( libsdp.options() )
+#### libsdp.sdp_helper.sdp_solver( libsdp.options() )
 
 Returns a solver object for performing the actual SDP optimization. Takes an options object as input. A minimal workflow would be:
 
 ```
-import libsdp
+from libsdp import sdp_options
+from libsdp.sdp_helper import sdp_solver
+from libsdp.sdp_helper import sdp_matrix
 
-options = libsdp.sdp_options()
+options = sdp_options()
 
 # change options if you don't like the defaults
 
-sdp = libsdp.sdp_solver(options)
+sdp = sdp_solver(options)
 
 b = [] # ... fill with appropriate elements
-F = [libsdp.sdp_matrix()] # ... fill with c, then rows of A
+F = [sdp_matrix()] # ... fill with c, then rows of A
 dimensions = [] # fill with block dimensions of primal solution
 maxiter = 100000 # maximum number of iterations ... can be used to force BPSDP to return early
 

--- a/examples/psi4_interface/g2_v2rdm_sdp.py
+++ b/examples/psi4_interface/g2_v2rdm_sdp.py
@@ -4,10 +4,7 @@ the semidefinite program for variational two-electron reduced density matrix the
 import numpy as np
 from numpy import einsum
 
-import sys
-sys.path.insert(0, '../../.')
-
-import libsdp
+from libsdp.sdp_helper import sdp_matrix
 
 class g2_v2rdm_sdp():
 
@@ -145,7 +142,7 @@ class g2_v2rdm_sdp():
         nblocks = len(self.dimensions)
     
         # F0  ... the integrals
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         #dum = np.einsum('ijkk->ij', tei)
         dum = -0.5 * np.einsum('ikkj->ij', tei)
@@ -223,7 +220,7 @@ class g2_v2rdm_sdp():
         self.b = []
 
         # 1 = 1
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
         F.column.append(1)
@@ -328,7 +325,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(d1_block_id)
                 F.row.append(i+1)
@@ -375,7 +372,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_aa[kl][0]
                 l = self.bas_aa[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(d2_block_id)
@@ -445,7 +442,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(self.block_id['d2ab'])
@@ -492,7 +489,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 il = self.ibas_ab[i, l]
@@ -533,7 +530,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - l* i* k j
                 li = self.ibas_ab[l, i]
@@ -586,7 +583,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -627,7 +624,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -668,7 +665,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + i* l* j k
                 il = self.ibas_ab[i, l]
@@ -696,7 +693,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + l* i* k j
                 li = self.ibas_ab[l, i]
@@ -722,7 +719,7 @@ class g2_v2rdm_sdp():
 
         ms = 0.5 * (self.nalpha - self.nbeta)
 
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         # <S^2>
         for i in range (0, self.nmo):
@@ -748,7 +745,7 @@ class g2_v2rdm_sdp():
             for j in range (0, self.nmo):
                 ij = self.ibas_ab[i, j]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
                     kk = self.ibas_ab[k, k]
@@ -766,7 +763,7 @@ class g2_v2rdm_sdp():
             for j in range (0, self.nmo):
                 ij = self.ibas_ab[i, j]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
                     kk = self.ibas_ab[k, k]
@@ -792,7 +789,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ab'])
                 F.row.append(ij + 1)
@@ -823,7 +820,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['g2ba'])
                 F.row.append(ij + 1)
@@ -854,7 +851,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ba'])
                 F.row.append(ij + 1)
@@ -885,7 +882,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ab'])
                 F.row.append(ij + 1)
@@ -921,7 +918,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for j in range (0, self.nmo):
    
@@ -949,7 +946,7 @@ class g2_v2rdm_sdp():
         for l in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1001,7 +998,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
    
@@ -1024,7 +1021,7 @@ class g2_v2rdm_sdp():
         for l in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1059,7 +1056,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for j in range (0, self.nmo):
    
@@ -1087,7 +1084,7 @@ class g2_v2rdm_sdp():
         for j in range (0, self.nmo):
             for l in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1132,7 +1129,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -1155,7 +1152,7 @@ class g2_v2rdm_sdp():
         for k in range (0, self.nmo):
             for l in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1179,7 +1176,7 @@ class g2_v2rdm_sdp():
         tr(g2) = n 
         """
     
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         # trace of g2aaaa
         n = self.nalpha * self.nmo - self.nalpha * (self.nalpha - 1.0)
@@ -1241,7 +1238,7 @@ class g2_v2rdm_sdp():
         :param n:        the trace
         """
    
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         for ij in range (0, len(self.bas_ab)):
             F.block_number.append(block_id)
@@ -1266,7 +1263,7 @@ class g2_v2rdm_sdp():
             j = self.bas_ab[ij][1]
             for kl in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
@@ -1305,7 +1302,7 @@ class g2_v2rdm_sdp():
             k = self.bas_ab[lk][1]
             for ji in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 j = self.bas_ab[ji][0]
                 i = self.bas_ab[ji][1]
@@ -1344,7 +1341,7 @@ class g2_v2rdm_sdp():
             j = self.bas_ab[ij][1]
             for kl in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
@@ -1389,7 +1386,7 @@ class g2_v2rdm_sdp():
                 lj = self.ibas_ab[l, j]
                 ki = self.ibas_ab[k, i]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['g2aa'])
                 F.row.append(lj + offset + 1)
@@ -1428,7 +1425,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
   
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
   
                 for k in range (0, self.nmo):
   
@@ -1463,7 +1460,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
 
@@ -1490,7 +1487,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
 

--- a/examples/psi4_interface/psi4_v2rdm.py
+++ b/examples/psi4_interface/psi4_v2rdm.py
@@ -5,9 +5,14 @@ import numpy as np
 from numpy import einsum
 
 import sys
-import libsdp
 from v2rdm_sdp import v2rdm_sdp
 from g2_v2rdm_sdp import g2_v2rdm_sdp
+
+import libsdp
+from libsdp.sdp_helper import sdp_solver
+from libsdp.sdpa_file_io import clean_sdpa_problem
+from libsdp.sdpa_file_io import read_sdpa_problem
+from libsdp.sdpa_file_io import write_sdpa_problem
 
 import psi4
 
@@ -74,9 +79,8 @@ def main():
     #my_sdp = v2rdm_sdp(nalpha, nbeta, nmo, oei, tei, q2 = True, constrain_spin = True, g2 = True)
     my_sdp = g2_v2rdm_sdp(nalpha, nbeta, nmo, oei, tei, d2 = True, q2 = True, constrain_spin = False)
 
-    b = my_sdp.b
-    F = my_sdp.F
     dimensions = my_sdp.dimensions
+    b, F = clean_sdpa_problem(my_sdp.b, my_sdp.F)
 
     # set options
     options = libsdp.sdp_options()
@@ -90,7 +94,7 @@ def main():
     options.penalty_parameter_scaling = 0.1
 
     # solve sdp
-    sdp = libsdp.sdp_solver(options, F, dimensions)
+    sdp = sdp_solver(options, F, dimensions)
     x = sdp.solve(b, maxiter)
 
     # now that the sdp is solved, we can play around with the primal and dual solutions

--- a/examples/psi4_interface/psi4_v2rdm.py
+++ b/examples/psi4_interface/psi4_v2rdm.py
@@ -8,7 +8,7 @@ import sys
 from v2rdm_sdp import v2rdm_sdp
 from g2_v2rdm_sdp import g2_v2rdm_sdp
 
-import libsdp
+from libsdp import sdp_options
 from libsdp.sdp_helper import sdp_solver
 from libsdp.sdpa_file_io import clean_sdpa_problem
 from libsdp.sdpa_file_io import read_sdpa_problem
@@ -83,7 +83,7 @@ def main():
     b, F = clean_sdpa_problem(my_sdp.b, my_sdp.F)
 
     # set options
-    options = libsdp.sdp_options()
+    options = sdp_options()
 
     maxiter = 5000000
 

--- a/examples/psi4_interface/v2rdm_sdp.py
+++ b/examples/psi4_interface/v2rdm_sdp.py
@@ -3,10 +3,7 @@ the semidefinite program for variational two-electron reduced density matrix the
 """
 import numpy as np
 
-import sys
-sys.path.insert(0, '../../.')
-
-import libsdp
+from libsdp.sdp_helper import sdp_matrix
 
 class v2rdm_sdp():
 
@@ -125,7 +122,7 @@ class v2rdm_sdp():
         nblocks = len(self.dimensions)
     
         # F0  ... the integrals
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
     
         #for i in range (0, nmo):
         #    for j in range (0, nmo):
@@ -206,7 +203,7 @@ class v2rdm_sdp():
         self.b = []
 
         # 1 = 1
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
         F.column.append(1)
@@ -288,7 +285,7 @@ class v2rdm_sdp():
         """
 
         # Tr(D1)
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
     
         for i in range (0, self.nmo):
             F.block_number.append(block_id)
@@ -309,7 +306,7 @@ class v2rdm_sdp():
         """
     
         # Tr(D2)
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
    
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
@@ -334,7 +331,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -361,7 +358,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -392,7 +389,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -434,7 +431,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(d1_block_id)
                 F.row.append(i+1)
@@ -481,7 +478,7 @@ class v2rdm_sdp():
                 k = self.bas_aa[kl][0]
                 l = self.bas_aa[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(d2_block_id)
@@ -551,7 +548,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(self.block_id['d2ab'])
@@ -598,7 +595,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 il = self.ibas_ab[i, l]
@@ -639,7 +636,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - l* i* k j
                 li = self.ibas_ab[l, i]
@@ -692,7 +689,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -733,7 +730,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -774,7 +771,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + i* l* k j
                 il = self.ibas_ab[i, l]
@@ -802,7 +799,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + l* i* j k
                 li = self.ibas_ab[l, i]
@@ -828,7 +825,7 @@ class v2rdm_sdp():
 
         ms = 0.5 * (self.nalpha - self.nbeta)
 
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
@@ -849,7 +846,7 @@ class v2rdm_sdp():
         #    for j in range (0, self.nmo):
         #        ij = self.ibas_ab[i, j]
 
-        #        F = libsdp.sdp_matrix()
+        #        F = sdp_matrix()
 
         #        for k in range (0, self.nmo):
         #            kk = self.ibas_ab[k, k]
@@ -866,7 +863,7 @@ class v2rdm_sdp():
         #    for j in range (0, self.nmo):
         #        ij = self.ibas_ab[i, j]
 
-        #        F = libsdp.sdp_matrix()
+        #        F = sdp_matrix()
 
         #        for k in range (0, self.nmo):
         #            kk = self.ibas_ab[k, k]
@@ -898,7 +895,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['d1a'])
                 F.row.append(i+1)
@@ -923,7 +920,7 @@ class v2rdm_sdp():
                 l = self.bas_ab[kl][1]
                 lk = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2ab'])
                 F.row.append(ij+1)
@@ -950,7 +947,7 @@ class v2rdm_sdp():
                 kl_ab = self.ibas_ab[k, l]
                 lk_ab = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2aa'])
                 F.row.append(ij+1)
@@ -992,7 +989,7 @@ class v2rdm_sdp():
                 kl_ab = self.ibas_ab[k, l]
                 lk_ab = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2bb'])
                 F.row.append(ij+1)

--- a/examples/pyscf_interface/g2_v2rdm_sdp.py
+++ b/examples/pyscf_interface/g2_v2rdm_sdp.py
@@ -4,10 +4,7 @@ the semidefinite program for variational two-electron reduced density matrix the
 import numpy as np
 from numpy import einsum
 
-import sys
-sys.path.insert(0, '../../.')
-
-import libsdp
+from libsdp.sdp_helper import sdp_matrix
 
 class g2_v2rdm_sdp():
 
@@ -145,7 +142,7 @@ class g2_v2rdm_sdp():
         nblocks = len(self.dimensions)
     
         # F0  ... the integrals
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         #dum = np.einsum('ijkk->ij', tei)
         dum = -0.5 * np.einsum('ikkj->ij', tei)
@@ -223,7 +220,7 @@ class g2_v2rdm_sdp():
         self.b = []
 
         # 1 = 1
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
         F.column.append(1)
@@ -328,7 +325,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(d1_block_id)
                 F.row.append(i+1)
@@ -375,7 +372,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_aa[kl][0]
                 l = self.bas_aa[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(d2_block_id)
@@ -445,7 +442,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(self.block_id['d2ab'])
@@ -492,7 +489,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 il = self.ibas_ab[i, l]
@@ -533,7 +530,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - l* i* k j
                 li = self.ibas_ab[l, i]
@@ -586,7 +583,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -627,7 +624,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -668,7 +665,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + i* l* j k
                 il = self.ibas_ab[i, l]
@@ -696,7 +693,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + l* i* k j
                 li = self.ibas_ab[l, i]
@@ -722,7 +719,7 @@ class g2_v2rdm_sdp():
 
         ms = 0.5 * (self.nalpha - self.nbeta)
 
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         # <S^2>
         for i in range (0, self.nmo):
@@ -748,7 +745,7 @@ class g2_v2rdm_sdp():
             for j in range (0, self.nmo):
                 ij = self.ibas_ab[i, j]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
                     kk = self.ibas_ab[k, k]
@@ -766,7 +763,7 @@ class g2_v2rdm_sdp():
             for j in range (0, self.nmo):
                 ij = self.ibas_ab[i, j]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
                     kk = self.ibas_ab[k, k]
@@ -792,7 +789,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ab'])
                 F.row.append(ij + 1)
@@ -823,7 +820,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['g2ba'])
                 F.row.append(ij + 1)
@@ -854,7 +851,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ba'])
                 F.row.append(ij + 1)
@@ -885,7 +882,7 @@ class g2_v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['g2ab'])
                 F.row.append(ij + 1)
@@ -921,7 +918,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for j in range (0, self.nmo):
    
@@ -949,7 +946,7 @@ class g2_v2rdm_sdp():
         for l in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1001,7 +998,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
    
@@ -1024,7 +1021,7 @@ class g2_v2rdm_sdp():
         for l in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1059,7 +1056,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for k in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for j in range (0, self.nmo):
    
@@ -1087,7 +1084,7 @@ class g2_v2rdm_sdp():
         for j in range (0, self.nmo):
             for l in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1132,7 +1129,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -1155,7 +1152,7 @@ class g2_v2rdm_sdp():
         for k in range (0, self.nmo):
             for l in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for i in range (0, self.nmo):
    
@@ -1179,7 +1176,7 @@ class g2_v2rdm_sdp():
         tr(g2) = n 
         """
     
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         # trace of g2aaaa
         n = self.nalpha * self.nmo - self.nalpha * (self.nalpha - 1.0)
@@ -1241,7 +1238,7 @@ class g2_v2rdm_sdp():
         :param n:        the trace
         """
    
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         for ij in range (0, len(self.bas_ab)):
             F.block_number.append(block_id)
@@ -1266,7 +1263,7 @@ class g2_v2rdm_sdp():
             j = self.bas_ab[ij][1]
             for kl in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
@@ -1305,7 +1302,7 @@ class g2_v2rdm_sdp():
             k = self.bas_ab[lk][1]
             for ji in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 j = self.bas_ab[ji][0]
                 i = self.bas_ab[ji][1]
@@ -1344,7 +1341,7 @@ class g2_v2rdm_sdp():
             j = self.bas_ab[ij][1]
             for kl in range (0, len(self.bas_ab)):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
@@ -1389,7 +1386,7 @@ class g2_v2rdm_sdp():
                 lj = self.ibas_ab[l, j]
                 ki = self.ibas_ab[k, i]
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['g2aa'])
                 F.row.append(lj + offset + 1)
@@ -1428,7 +1425,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
   
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
   
                 for k in range (0, self.nmo):
   
@@ -1463,7 +1460,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
 
@@ -1490,7 +1487,7 @@ class g2_v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
 
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 for k in range (0, self.nmo):
 

--- a/examples/pyscf_interface/pyscf_v2rdm.py
+++ b/examples/pyscf_interface/pyscf_v2rdm.py
@@ -9,7 +9,7 @@ import sys
 from v2rdm_sdp import v2rdm_sdp
 from g2_v2rdm_sdp import g2_v2rdm_sdp
 
-import libsdp
+from libsdp import sdp_options
 from libsdp.sdp_helper import sdp_solver
 from libsdp.sdpa_file_io import clean_sdpa_problem
 from libsdp.sdpa_file_io import read_sdpa_problem
@@ -85,7 +85,7 @@ def main():
     dimensions = my_sdp.dimensions
 
     # set options
-    options = libsdp.sdp_options()
+    options = sdp_options()
 
     maxiter = 100000
 

--- a/examples/pyscf_interface/pyscf_v2rdm.py
+++ b/examples/pyscf_interface/pyscf_v2rdm.py
@@ -6,10 +6,11 @@ from numpy import einsum
 
 import sys
 
-import libsdp
 from v2rdm_sdp import v2rdm_sdp
 from g2_v2rdm_sdp import g2_v2rdm_sdp
 
+import libsdp
+from libsdp.sdp_helper import sdp_solver
 from libsdp.sdpa_file_io import clean_sdpa_problem
 from libsdp.sdpa_file_io import read_sdpa_problem
 from libsdp.sdpa_file_io import write_sdpa_problem
@@ -104,13 +105,13 @@ def main():
     options.dynamic_cg_convergence    = False
 
     # solve sdp
-    sdp_solver = libsdp.sdp_solver(options, F, dimensions)
-    x = sdp_solver.solve(b, maxiter)
+    sdp = sdp_solver(options, F, dimensions)
+    x = sdp.solve(b, maxiter)
 
     # now that the sdp is solved, we can play around with the primal and dual solutions
-    z = np.array(sdp_solver.get_z())
-    c = np.array(sdp_solver.get_c())
-    y = np.array(sdp_solver.get_y())
+    z = np.array(sdp.get_z())
+    c = np.array(sdp.get_c())
+    y = np.array(sdp.get_y())
 
     dual_energy = np.dot(b, y)
     primal_energy = np.dot(c, x)
@@ -124,10 +125,10 @@ def main():
     #print(dum)
 
     # action of A^T on y
-    ATy = np.array(sdp_solver.get_ATu(y))
+    ATy = np.array(sdp.get_ATu(y))
 
     # action of A on x 
-    Ax = np.array(sdp_solver.get_Au(x))
+    Ax = np.array(sdp.get_Au(x))
 
     dual_error = c - z - ATy
     primal_error = Ax - b

--- a/examples/pyscf_interface/v2rdm_sdp.py
+++ b/examples/pyscf_interface/v2rdm_sdp.py
@@ -3,10 +3,7 @@ the semidefinite program for variational two-electron reduced density matrix the
 """
 import numpy as np
 
-import sys
-sys.path.insert(0, '../../.')
-
-import libsdp
+from libsdp.sdp_helper import sdp_matrix
 
 class v2rdm_sdp():
 
@@ -125,7 +122,7 @@ class v2rdm_sdp():
         nblocks = len(self.dimensions)
     
         # F0  ... the integrals
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
     
         #for i in range (0, nmo):
         #    for j in range (0, nmo):
@@ -206,7 +203,7 @@ class v2rdm_sdp():
         self.b = []
 
         # 1 = 1
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
         F.column.append(1)
@@ -288,7 +285,7 @@ class v2rdm_sdp():
         """
 
         # Tr(D1)
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
     
         for i in range (0, self.nmo):
             F.block_number.append(block_id)
@@ -309,7 +306,7 @@ class v2rdm_sdp():
         """
     
         # Tr(D2)
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
    
         F.block_number.append(self.block_id['1'])
         F.row.append(1)
@@ -334,7 +331,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -361,7 +358,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -392,7 +389,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 for k in range (0, self.nmo):
    
@@ -434,7 +431,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(d1_block_id)
                 F.row.append(i+1)
@@ -481,7 +478,7 @@ class v2rdm_sdp():
                 k = self.bas_aa[kl][0]
                 l = self.bas_aa[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(d2_block_id)
@@ -551,7 +548,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + k* l* j i
                 F.block_number.append(self.block_id['d2ab'])
@@ -598,7 +595,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 il = self.ibas_ab[i, l]
@@ -639,7 +636,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - l* i* k j
                 li = self.ibas_ab[l, i]
@@ -692,7 +689,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -733,7 +730,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # - i* l* j k
                 if i != l and k != j:
@@ -774,7 +771,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + i* l* k j
                 il = self.ibas_ab[i, l]
@@ -802,7 +799,7 @@ class v2rdm_sdp():
                 k = self.bas_ab[kl][0]
                 l = self.bas_ab[kl][1]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 # + l* i* j k
                 li = self.ibas_ab[l, i]
@@ -828,7 +825,7 @@ class v2rdm_sdp():
 
         ms = 0.5 * (self.nalpha - self.nbeta)
 
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
 
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
@@ -849,7 +846,7 @@ class v2rdm_sdp():
         #    for j in range (0, self.nmo):
         #        ij = self.ibas_ab[i, j]
 
-        #        F = libsdp.sdp_matrix()
+        #        F = sdp_matrix()
 
         #        for k in range (0, self.nmo):
         #            kk = self.ibas_ab[k, k]
@@ -866,7 +863,7 @@ class v2rdm_sdp():
         #    for j in range (0, self.nmo):
         #        ij = self.ibas_ab[i, j]
 
-        #        F = libsdp.sdp_matrix()
+        #        F = sdp_matrix()
 
         #        for k in range (0, self.nmo):
         #            kk = self.ibas_ab[k, k]
@@ -898,7 +895,7 @@ class v2rdm_sdp():
         for i in range (0, self.nmo):
             for j in range (0, self.nmo):
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
 
                 F.block_number.append(self.block_id['d1a'])
                 F.row.append(i+1)
@@ -923,7 +920,7 @@ class v2rdm_sdp():
                 l = self.bas_ab[kl][1]
                 lk = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2ab'])
                 F.row.append(ij+1)
@@ -950,7 +947,7 @@ class v2rdm_sdp():
                 kl_ab = self.ibas_ab[k, l]
                 lk_ab = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2aa'])
                 F.row.append(ij+1)
@@ -992,7 +989,7 @@ class v2rdm_sdp():
                 kl_ab = self.ibas_ab[k, l]
                 lk_ab = self.ibas_ab[l, k]
    
-                F = libsdp.sdp_matrix()
+                F = sdp_matrix()
    
                 F.block_number.append(self.block_id['d2bb'])
                 F.row.append(ij+1)

--- a/examples/python_interface/sdpa_format.py
+++ b/examples/python_interface/sdpa_format.py
@@ -1,7 +1,7 @@
 import numpy as np
 import sys
-import libsdp
 
+from libsdp import sdp_options
 from libsdp.sdpa_file_io import read_sdpa_problem
 from libsdp.sdp_helper import sdp_solver
 
@@ -31,7 +31,7 @@ def main():
     b, A, block_dim = read_sdpa_problem(filename)
 
     # set options
-    options = libsdp.sdp_options()
+    options = sdp_options()
     
     maxiter = 500000
     

--- a/examples/python_interface/sdpa_format.py
+++ b/examples/python_interface/sdpa_format.py
@@ -1,7 +1,9 @@
 import numpy as np
 import sys
 import libsdp
+
 from libsdp.sdpa_file_io import read_sdpa_problem
+from libsdp.sdp_helper import sdp_solver
 
 def main():
 
@@ -48,7 +50,7 @@ def main():
     # solve sdp (python) 
 
     # solve sdp (c++)
-    sdp = libsdp.sdp_solver(options, A, block_dim)
+    sdp = sdp_solver(options, A, block_dim)
     x = sdp.solve(b, maxiter)
     c = np.array(sdp.get_c())
 

--- a/libsdp/sdp_helper.py
+++ b/libsdp/sdp_helper.py
@@ -1,0 +1,71 @@
+import libsdp
+import numpy as np
+import os
+
+# minimal matrix object for sparse SDPA format
+class sdp_matrix:
+    def __init__(self,):
+        self.row: list = []
+        self.column: list = []
+        self.block_number: list = []
+        self.value: list = []
+
+def python_to_cpp_sdp_matrix(Fi: sdp_matrix):
+    """
+        convert a Python SDPA matrix object to a C++ one
+
+        :param Fi: a Python SDPA matrix object (sdp_matrix)
+        :return tf: a C++ SDPA matrix object (libsdp.sdp_matrix)
+    """
+
+    tF = libsdp.sdp_matrix()
+    tF.row = Fi.row 
+    tF.column = Fi.column 
+    tF.value = Fi.value 
+    tF.block_number = Fi.block_number 
+
+    return tF
+
+class sdp_solver:
+    def __init__(self, options, F, dimensions):
+        """
+            a Python wrapper to the libsdp.sdp_solver object
+
+            :param options: libsdp.options object
+            :param F: a list of python sdp_matrix objects
+            :param dimensions: a list of primal block dimensions for the problem
+        """
+
+        # convert python SDPA matrix objects to C++ ones
+        self.F = []
+        for Fi in F:
+            self.F.append(python_to_cpp_sdp_matrix(Fi))
+   
+        self.options = options
+        self.dimensions = dimensions
+
+        self.sdp_solver = libsdp.sdp_solver(self.options, self.F, self.dimensions)
+
+    def solve(self, b, maxdim, primal_rank = None) :
+
+        self.maxdim = maxdim
+
+        if primal_rank is None : 
+            return self.sdp_solver.solve(b, maxdim)
+        return self.sdp_solver.solve(b, maxdim, primal_rank)
+
+    def get_ATu(self, u):
+        return self.sdp_solver.get_ATu(u)
+
+    def get_Au(self, u):
+        return self.sdp_solver.get_Au(u)
+
+    def get_y(self):
+        return self.sdp_solver.get_y()
+
+    def get_z(self):
+        return self.sdp_solver.get_z()
+
+    def get_c(self):
+        return self.sdp_solver.get_c()
+

--- a/libsdp/sdpa_file_io.py
+++ b/libsdp/sdpa_file_io.py
@@ -1,4 +1,3 @@
-import libsdp
 import numpy as np
 
 from libsdp.sdp_helper import sdp_matrix
@@ -184,7 +183,7 @@ def write_sdpa_problem(filename, c, Fi, block_dimensions):
     # Fi
     for i in range (0, len(Fi)):
         s = ''
-        for j in range (0, len(Fi[i].block_number.size)):
+        for j in range (0, len(Fi[i].block_number)):
             if Fi[i].row[j] <= Fi[i].column[j] : 
                 f.write("%5i %5i %5i %5i %20.12e\n" % (i, Fi[i].block_number[j], Fi[i].row[j], Fi[i].column[j], Fi[i].value[j]) )
 

--- a/libsdp/sdpa_file_io.py
+++ b/libsdp/sdpa_file_io.py
@@ -1,6 +1,8 @@
 import libsdp
 import numpy as np
 
+from libsdp.sdp_helper import sdp_matrix
+
 def read_sdpa_problem(filename):
 
     """
@@ -83,7 +85,7 @@ def read_sdpa_problem(filename):
     
     current_block = 0
     
-    F = libsdp.sdp_matrix()
+    F = sdp_matrix()
     
     for i in range(offset+4,len(my_file)):
     
@@ -99,7 +101,7 @@ def read_sdpa_problem(filename):
             Fi.append(F)
     
             # new sdp_matrix
-            F = libsdp.sdp_matrix()
+            F = sdp_matrix()
     
         # append constraint matrix values
         F.block_number.append(int(temp[1]))
@@ -182,7 +184,7 @@ def write_sdpa_problem(filename, c, Fi, block_dimensions):
     # Fi
     for i in range (0, len(Fi)):
         s = ''
-        for j in range (0, Fi[i].block_number.size()):
+        for j in range (0, len(Fi[i].block_number.size)):
             if Fi[i].row[j] <= Fi[i].column[j] : 
                 f.write("%5i %5i %5i %5i %20.12e\n" % (i, Fi[i].block_number[j], Fi[i].row[j], Fi[i].column[j], Fi[i].value[j]) )
 
@@ -195,16 +197,15 @@ def clean_sdpa_problem(c, Fi):
 
     :param c: the constraint vector
 
-    :param Fi: a list of sdp_matrix objects defining the constraints. the
-               first object in the  which (F0) defines the objective
-               function
+    :param Fi: a list of Python SDPA matrix objects defining the 
+               constraints. the first object in the  which (F0) 
+               defines the objective function
 
     :return c: a pruned the constraint vector
 
-    :return Fi: a pruned list of sdp_matrix objects defining the
+    :return Fi: a pruned list of C++ SDPA matrix objects defining the
                 constraints. the first object in the  which (F0) defines
                 the objective function
-               
     """ 
 
     # strategy is to go through every constraint and uniqify
@@ -212,12 +213,11 @@ def clean_sdpa_problem(c, Fi):
     new_c = []
     for mi in range(len(Fi)):
         unique_vals = defaultdict(lambda: 0.) # lambda: 0. is def f(): return 0.
-        # each Fi[mi] is a libsdp._libsdp.int_vector object which has the method .size() returning length
-        for j in range(Fi[mi].row.size()):
+        for j in range(len(Fi[mi].row)):
             key = (Fi[mi].block_number[j], Fi[mi].row[j], Fi[mi].column[j])
             unique_vals[key] += Fi[mi].value[j]
 
-        F = libsdp.sdp_matrix()
+        F = sdp_matrix()
         for key, val in unique_vals.items():
             if np.isclose(val, 0., atol=1.0E-14):
                 continue
@@ -228,7 +228,7 @@ def clean_sdpa_problem(c, Fi):
             F.value.append(val)
 
         # such constraints look like 0 = 0 ... don't include them
-        if F.row.size() == 0 :
+        if len(F.row) == 0 :
 
             if mi == 0 :
                 print('')
@@ -244,6 +244,7 @@ def clean_sdpa_problem(c, Fi):
 
             continue
 
+        # convert python SDPA matrix object to C++ one, then add to list
         new_F.append(F)
         if mi > 0:
             new_c.append(c[mi-1])

--- a/libsdp/src/sdp_helper.cc
+++ b/libsdp/src/sdp_helper.cc
@@ -24,6 +24,7 @@
  *  @END LICENSE
  */
 
+#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -40,20 +41,20 @@
 #include "blas_helper.h"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-std::vector<double> empty_list = {};
+std::vector<int> empty_list = {};
 
 namespace libsdp {
 
 void export_SDPHelper(py::module& m) {
 
     // export SDP options
-
     py::class_<SDPOptions> options(m, "sdp_options");
 
     options.def(py::init< >())
@@ -73,32 +74,16 @@ void export_SDPHelper(py::module& m) {
         .def_readwrite("sdp_algorithm",&SDPOptions::algorithm)
         .def_readwrite("procedure",&SDPOptions::procedure);
 
-    py::class_<my_vector<int>> (m, "int_vector")
-        .def(py::init<>())
-        .def("__getitem__", &my_vector<int>::operator[])
-        .def("size", &my_vector<int>::size)
-        .def("append", &my_vector<int>::append)
-        .def("get", &my_vector<int>::get);
-
-    py::class_<my_vector<double>> (m, "double_vector")
-        .def(py::init<>())
-        .def("__getitem__", &my_vector<double>::operator[])
-        .def("size", &my_vector<double>::size)
-        .def("append", &my_vector<double>::append)
-        .def("get", &my_vector<double>::get);
-
     // export SDPMatrix type
-    py::class_<SDPMatrix> matrix(m, "sdp_matrix");
-
-    matrix.def(py::init< >())
-        .def_readwrite("block_number",&SDPMatrix::block_number)
-        .def_readwrite("row",&SDPMatrix::row)
-        .def_readwrite("column",&SDPMatrix::column)
-        .def_readwrite("value",&SDPMatrix::value)
-        .def_readwrite("id",&SDPMatrix::id);
+    py::class_<SDPMatrix>(m, "sdp_matrix")
+        .def(py::init<>())
+        .def_readwrite("block_number", &SDPMatrix::block_number)
+        .def_readwrite("row", &SDPMatrix::row)
+        .def_readwrite("column", &SDPMatrix::column)
+        .def_readwrite("value", &SDPMatrix::value)
+        .def_readwrite("id", &SDPMatrix::id);
 
     // export SDP solver
-
     py::class_<SDPHelper, std::shared_ptr<SDPHelper> >(m, "sdp_solver")
         .def(py::init<SDPOptions, std::vector<SDPMatrix> &, std::vector<int> & >())
         .def("solve", 
@@ -116,7 +101,6 @@ void export_SDPHelper(py::module& m) {
         .def("get_y", &SDPHelper::get_y)
         .def("get_z", &SDPHelper::get_z)
         .def("get_c", &SDPHelper::get_c);
-
 }
 
 PYBIND11_MODULE(_libsdp, m) {
@@ -134,7 +118,6 @@ static void bpsdp_monitor(int print_level, int oiter, int iiter, double energy_p
             fflush(stdout);
         }
     }
-
 }
 
 /// RRSDP monitor callback function
@@ -147,7 +130,6 @@ static void rrsdp_monitor(int print_level, int oiter, int iiter, double lagrangi
             fflush(stdout);
         }
     }
-
 }
 
 /// SDPHelper constructor
@@ -240,7 +222,8 @@ SDPHelper::SDPHelper(SDPOptions options,
             size_t id = off + my_row * primal_block_dim[my_block] + my_column;
 
             // add to matrix object
-            Fi_[i-1].id.append(id);
+            //Fi_[i-1].id.append(id);
+            Fi_[i-1].id.push_back(id);
         }
     }
 
@@ -248,8 +231,10 @@ SDPHelper::SDPHelper(SDPOptions options,
     FTi_.resize(n_primal_);
     for (size_t i = 0; i < Fi_.size(); i++) {
         for (size_t j = 0; j < Fi_[i].block_number.size(); j++) {
-            FTi_[Fi_[i].id[j]].id.append(i);
-            FTi_[Fi_[i].id[j]].value.append(Fi_[i].value[j]);
+            //FTi_[Fi_[i].id[j]].id.append(i);
+            //FTi_[Fi_[i].id[j]].value.append(Fi_[i].value[j]);
+            FTi_[Fi_[i].id[j]].id.push_back(i);
+            FTi_[Fi_[i].id[j]].value.push_back(Fi_[i].value[j]);
         }
     }
 

--- a/libsdp/src/sdp_helper.h
+++ b/libsdp/src/sdp_helper.h
@@ -38,24 +38,15 @@
 namespace libsdp {
 
 /// a constraint matrix in sparse SDPA format
-template<typename T>
-struct my_vector {
-    std::vector<T> data;
-    std::vector<T> &get() { return data; }
-    void append(T value) { data.push_back(value); }
-    size_t size() const { return data.size(); }
-    T& operator[](size_t id) { return data[id]; }
-};
-
 struct SDPMatrix {
     SDPMatrix(){};
-    my_vector<int> block_number;
-    my_vector<int> row;
-    my_vector<int> column;
-    my_vector<double> value;
+    std::vector<int> block_number;
+    std::vector<int> row;
+    std::vector<int> column;
+    std::vector<double> value;
 
     /// composite index, accounting for row, column, block offset
-    my_vector<int> id;
+    std::vector<int> id;
 };
 
 class SDPHelper{


### PR DESCRIPTION
appending elements to libsdp.sdp_matrix() is very slow. this PR creates a new sdp_matrix() object

libsdp.sdp_helper.sdp_matrix()

that should be used instead. In order to call the SDP solvers, these matrix objects must be converted to the type used on the C++ side. A user shouldn't have to worry about this detail, so this PR also implements a wrapper to the libsdp.sdp_solver()[libsdp.sdp_helper.sdp_solver()] that takes care of the conversion automatically. Examples and readme are updated to account for these differences.